### PR TITLE
Support plugin prefixes

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -97,16 +97,18 @@ const getEndpoints = ({ collectionTypes, singleTypes }, schemas) => {
       ({ schema }) =>
         types.findIndex(({ singularName }) => singularName === schema.singularName) !== -1
     )
-    .map(({ schema: { kind, singularName, pluralName }, uid }) => {
+    .map(({ schema: { kind, singularName, pluralName }, uid, plugin }) => {
       const options = types.find((config) => config.singularName === singularName);
       const { queryParams, queryLimit } = options;
+
+      const pluginPrefix = plugin ? `${plugin}/` : '';
 
       if (kind === 'singleType') {
         return {
           singularName,
           kind,
           uid,
-          endpoint: `/api/${singularName}`,
+          endpoint: `/api/${pluginPrefix}${singularName}`,
           queryParams: queryParams || {
             populate: '*',
           },
@@ -118,7 +120,7 @@ const getEndpoints = ({ collectionTypes, singleTypes }, schemas) => {
         pluralName,
         kind,
         uid,
-        endpoint: `/api/${pluralName}`,
+        endpoint: `/api/${pluginPrefix}${pluralName}`,
         queryParams: {
           ...(queryParams || {}),
           pagination: {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -94,14 +94,16 @@ const getEndpoints = ({ collectionTypes, singleTypes }, schemas) => {
 
   const endpoints = schemas
     .filter(
-      ({ schema }) =>
+      ({ schema, uid }) =>
+        !uid.startsWith('admin::') &&
         types.findIndex(({ singularName }) => singularName === schema.singularName) !== -1
     )
     .map(({ schema: { kind, singularName, pluralName }, uid, plugin }) => {
       const options = types.find((config) => config.singularName === singularName);
       const { queryParams, queryLimit } = options;
 
-      const pluginPrefix = plugin ? `${plugin}/` : '';
+      // Prepend plugin prefix except for users as their endpoint is /api/users
+      const pluginPrefix = plugin && singularName !== 'user' ? `${plugin}/` : '';
 
       if (kind === 'singleType') {
         return {


### PR DESCRIPTION
This PR fixes issue gatsby-uc/plugins#342 by looking at plugin names in the schema and prepending them to endpoint urls.
Ignoring admin types (uid starting with `admin::`) and handling the exceptional case of the user type which comes from the plugin `users-permissions` but is available via the `/api/users/` endpoint.

A simple test to get a list of all locales:
```js
//gatsby-config.js
{
    resolve: 'gatsby-source-strapi',
    options: {
        collectionTypes: ['locale']
    }
}
```