### PR TITLE
update gatsby version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier": "2.1.2"
   },
   "peerDependencies": {
-    "gatsby": "^4.0.0",
+    "gatsby": "^4.0.0 || ^5.0.0",
     "gatsby-plugin-image": "^2.5.1",
     "gatsby-plugin-sharp": "^4.5.1",
     "sharp": "^0.29.0"


### PR DESCRIPTION
## Why

There is a warning because of Gatsby v5. I installed the plugin and configured it and it works great, so just update the version.

```
warn Plugin gatsby-source-strapi is not compatible with your gatsby version 5.2.0 - It requires gatsby@^4.0.0
```